### PR TITLE
Nit 343 upgrade lambda function nodejs version

### DIFF
--- a/monitoring/lambda.tf
+++ b/monitoring/lambda.tf
@@ -1,5 +1,5 @@
 resource "aws_lambda_function" "notify_slack_alarm" {
-  runtime          = "nodejs12.x"
+  runtime          = "nodejs16.x"
   role             = aws_iam_role.lambda_role.arn
   filename         = data.archive_file.alarm_lambda_handler_zip.output_path
   function_name    = local.lambda_name_alarm

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -36,5 +36,5 @@ variable "alarms_config" {
 
 variable "channel" {
   description = "Slack channel to send notification"
-  default     = "cr-auto-stop-alerts" //Channel dosnt exists just default value
+  default     = "cr-auto-stop-alerts" //Channel doesn't exist, that's just a default value
 }

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -39,7 +39,7 @@ generate "provider" {
   contents  = <<EOF
 provider "aws" {
   region  = "${get_env("TG_REGION", "AWS-REGION")}"
-  version = "~> 3.33.0"
+  version = "~> 3.75.2"
 }
 EOF
 }

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   alias   = "delius_prod_acct_r53_delegation"
   region  = var.region
-  version = "~> 3.33.0"
+  version = "~> 3.75.2"
 
   # Role in delius prod account for managing R53 NS delegation records
   assume_role {


### PR DESCRIPTION
Upgrade AWS provider fro v3.33.0 to v3.75.2 to enable lambda nodejs version upgrade.

Upgrade lambda function nodejs version from v12 to v16.

Ticket no. https://dsdmoj.atlassian.net/browse/NIT-343.