### PR TITLE
Comment out chaosmonkey resources creation

### DIFF
--- a/testing/chaosmonkey/batch.tf
+++ b/testing/chaosmonkey/batch.tf
@@ -1,73 +1,76 @@
-# Create a dedicated security group with no ingress for the batch compute environment
-# Requires egress for pulling images from container registry and connection to endpoints
-resource "aws_security_group" "ce_sg" {
-  name        = "${local.name_prefix}-testing-out"
-  vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_id
-  description = "Chaosmonkey Testing Out"
-  tags = merge(
-    var.tags,
-    {
-      "Name" = "${local.name_prefix}-testing-out"
-      "Type" = "Private"
-    },
-  )
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_security_group_rule" "egress_internet" {
-  security_group_id = aws_security_group.ce_sg.id
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  type              = "egress"
-  description       = "connect to container registry and endpoint"
-  cidr_blocks       = ["0.0.0.0/0"]
-}
-
-resource "aws_batch_compute_environment" "batch_ce" {
-  compute_environment_name_prefix = "${local.name_prefix}-testing-ce"
-
-  compute_resources {
-    instance_role = aws_iam_instance_profile.ecs_instance_profile.arn
-    ec2_key_pair  = data.terraform_remote_state.vpc.outputs.ssh_deployer_key
-    instance_type = var.ce_instances
-
-    max_vcpus = var.ce_max_vcpu
-    min_vcpus = var.ce_min_vcpu
-
-    security_group_ids = [aws_security_group.ce_sg.id]
-
-    subnets = [
-      data.terraform_remote_state.vpc.outputs.vpc_private-subnet-az1,
-      data.terraform_remote_state.vpc.outputs.vpc_private-subnet-az2,
-      data.terraform_remote_state.vpc.outputs.vpc_private-subnet-az3,
-    ]
-
-    type = "EC2"
-
-    tags = var.tags
-  }
-
-  service_role = aws_iam_role.batch_service_role.arn
-  type         = "MANAGED"
-  depends_on   = [aws_iam_role_policy_attachment.batch_service_role_policy_attachment]
-
-  # AWS Batch manages the desired_vcpus value dynamically - don't try and adjust
-  lifecycle {
-    ignore_changes        = [compute_resources.0.desired_vcpus]
-    create_before_destroy = true
-  }
-}
-
-resource "aws_batch_job_queue" "batch_queue" {
-  name  = "${local.name_prefix}-testing-queue"
-  state = var.ce_queue_state
-
-  # This is a standalone CE with a single queue - therefore priority is fixed
-  priority             = 1
-  compute_environments = [aws_batch_compute_environment.batch_ce.arn]
-}
+## Tests implemented by AdRoc in dev environments only (not in any other higher 
+## environments) so removing the resources in dev and keeping the code for reference only
+#
+## Create a dedicated security group with no ingress for the batch compute environment
+## Requires egress for pulling images from container registry and connection to endpoints
+#resource "aws_security_group" "ce_sg" {
+#  name        = "${local.name_prefix}-testing-out"
+#  vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_id
+#  description = "Chaosmonkey Testing Out"
+#  tags = merge(
+#    var.tags,
+#    {
+#      "Name" = "${local.name_prefix}-testing-out"
+#      "Type" = "Private"
+#    },
+#  )
+#
+#  lifecycle {
+#    create_before_destroy = true
+#  }
+#}
+#
+#resource "aws_security_group_rule" "egress_internet" {
+#  security_group_id = aws_security_group.ce_sg.id
+#  from_port         = 0
+#  to_port           = 0
+#  protocol          = "-1"
+#  type              = "egress"
+#  description       = "connect to container registry and endpoint"
+#  cidr_blocks       = ["0.0.0.0/0"]
+#}
+#
+#resource "aws_batch_compute_environment" "batch_ce" {
+#  compute_environment_name_prefix = "${local.name_prefix}-testing-ce"
+#
+#  compute_resources {
+#    instance_role = aws_iam_instance_profile.ecs_instance_profile.arn
+#    ec2_key_pair  = data.terraform_remote_state.vpc.outputs.ssh_deployer_key
+#    instance_type = var.ce_instances
+#
+#    max_vcpus = var.ce_max_vcpu
+#    min_vcpus = var.ce_min_vcpu
+#
+#    security_group_ids = [aws_security_group.ce_sg.id]
+#
+#    subnets = [
+#      data.terraform_remote_state.vpc.outputs.vpc_private-subnet-az1,
+#      data.terraform_remote_state.vpc.outputs.vpc_private-subnet-az2,
+#      data.terraform_remote_state.vpc.outputs.vpc_private-subnet-az3,
+#    ]
+#
+#    type = "EC2"
+#
+#    tags = var.tags
+#  }
+#
+#  service_role = aws_iam_role.batch_service_role.arn
+#  type         = "MANAGED"
+#  depends_on   = [aws_iam_role_policy_attachment.batch_service_role_policy_attachment]
+#
+#  # AWS Batch manages the desired_vcpus value dynamically - don't try and adjust
+#  lifecycle {
+#    ignore_changes        = [compute_resources.0.desired_vcpus]
+#    create_before_destroy = true
+#  }
+#}
+#
+#resource "aws_batch_job_queue" "batch_queue" {
+#  name  = "${local.name_prefix}-testing-queue"
+#  state = var.ce_queue_state
+#
+#  # This is a standalone CE with a single queue - therefore priority is fixed
+#  priority             = 1
+#  compute_environments = [aws_batch_compute_environment.batch_ce.arn]
+#}
 

--- a/testing/chaosmonkey/batch.tf
+++ b/testing/chaosmonkey/batch.tf
@@ -1,6 +1,7 @@
 ## Tests implemented by AdRoc in dev environments only (not in any other higher 
 ## environments) so removing the resources in dev and keeping the code for reference only
 #
+#
 ## Create a dedicated security group with no ingress for the batch compute environment
 ## Requires egress for pulling images from container registry and connection to endpoints
 #resource "aws_security_group" "ce_sg" {

--- a/testing/chaosmonkey/chaosmonkey_job.tf
+++ b/testing/chaosmonkey/chaosmonkey_job.tf
@@ -1,37 +1,40 @@
-# Create Chaosmonkey specific AWS Batch Job Definition
-data "template_file" "chaosmonkey_job_template" {
-  template = file("./templates/batch_jobs/chaosmonkey.tpl")
-
-  vars = {
-    job_image  = var.chaosmonkey_job_image
-    job_role   = aws_iam_role.job_role.arn
-    job_memory = var.chaosmonkey_job_memory
-    job_vcpus  = var.chaosmonkey_job_vcpus
-    # Map of environment vars - These can be appended to at run time
-    job_envvars = jsonencode(var.chaosmonkey_job_envvars)
-    # Job specific ulimits - with horrible TF workaround for keeping integers post marshalling - fixed in TF 0.12
-    # see https://github.com/hashicorp/terraform/issues/17033
-    job_ulimits = replace(
-      replace(
-        jsonencode(var.chaosmonkey_job_ulimits),
-        "/\"([[:digit:]]+)\"/",
-        "$1",
-      ),
-      "string:",
-      "",
-    )
-  }
-}
-
-resource "aws_batch_job_definition" "chaosmonkey_job_def" {
-  name = "${local.name_prefix}-testing-job"
-  type = "container"
-
-  retry_strategy {
-    attempts = var.chaosmonkey_job_retries
-  }
-
-  # Rendered Job Definition from template
-  container_properties = data.template_file.chaosmonkey_job_template.rendered
-}
+## Tests implemented by AdRoc in dev environments only (not in any other higher 
+## environments) so removing the resources in dev and keeping the code for reference only
+#
+## Create Chaosmonkey specific AWS Batch Job Definition
+#data "template_file" "chaosmonkey_job_template" {
+#  template = file("./templates/batch_jobs/chaosmonkey.tpl")
+#
+#  vars = {
+#    job_image  = var.chaosmonkey_job_image
+#    job_role   = aws_iam_role.job_role.arn
+#    job_memory = var.chaosmonkey_job_memory
+#    job_vcpus  = var.chaosmonkey_job_vcpus
+#    # Map of environment vars - These can be appended to at run time
+#    job_envvars = jsonencode(var.chaosmonkey_job_envvars)
+#    # Job specific ulimits - with horrible TF workaround for keeping integers post marshalling - fixed in TF 0.12
+#    # see https://github.com/hashicorp/terraform/issues/17033
+#    job_ulimits = replace(
+#      replace(
+#        jsonencode(var.chaosmonkey_job_ulimits),
+#        "/\"([[:digit:]]+)\"/",
+#        "$1",
+#      ),
+#      "string:",
+#      "",
+#    )
+#  }
+#}
+#
+#resource "aws_batch_job_definition" "chaosmonkey_job_def" {
+#  name = "${local.name_prefix}-testing-job"
+#  type = "container"
+#
+#  retry_strategy {
+#    attempts = var.chaosmonkey_job_retries
+#  }
+#
+#  # Rendered Job Definition from template
+#  container_properties = data.template_file.chaosmonkey_job_template.rendered
+#}
 

--- a/testing/chaosmonkey/chaosmonkey_job.tf
+++ b/testing/chaosmonkey/chaosmonkey_job.tf
@@ -1,6 +1,7 @@
 ## Tests implemented by AdRoc in dev environments only (not in any other higher 
 ## environments) so removing the resources in dev and keeping the code for reference only
 #
+#
 ## Create Chaosmonkey specific AWS Batch Job Definition
 #data "template_file" "chaosmonkey_job_template" {
 #  template = file("./templates/batch_jobs/chaosmonkey.tpl")

--- a/testing/chaosmonkey/iam.tf
+++ b/testing/chaosmonkey/iam.tf
@@ -1,70 +1,73 @@
-# Fetch local context, e.g. current account id for arn strings
-data "aws_caller_identity" "current" {
-}
-
-# Create a Service Role for AWS Batch to run under
-data "template_file" "batch_assume_role_template" {
-  template = file(
-    "${path.module}/templates/iam_policies/batch_assume_policy.tpl",
-  )
-
-  vars = {}
-}
-
-resource "aws_iam_role" "batch_service_role" {
-  name = "${local.name_prefix}-batch-role"
-
-  assume_role_policy = data.template_file.batch_assume_role_template.rendered
-}
-
-# Use existing managed iam policy for ECS instances - May want to copy and manage this separately
-resource "aws_iam_role_policy_attachment" "batch_service_role_policy_attachment" {
-  role       = aws_iam_role.batch_service_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
-}
-
-# Create the EC2 Instance role ECS instances will run under
-data "template_file" "ecs_assume_role_template" {
-  template = file(
-    "${path.module}/templates/iam_policies/ecs_assume_policy.tpl",
-  )
-
-  vars = {}
-}
-
-resource "aws_iam_role" "ecs_instance_role" {
-  name = "${local.name_prefix}-ecs-role"
-
-  assume_role_policy = data.template_file.ecs_assume_role_template.rendered
-}
-
-# Use existing managed iam policy for ECS instances - May want to copy and manage this separately
-resource "aws_iam_role_policy_attachment" "ecs_instance_role_policy_attachement" {
-  role       = aws_iam_role.ecs_instance_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
-}
-
-resource "aws_iam_instance_profile" "ecs_instance_profile" {
-  name = "${local.name_prefix}-ecs-profile"
-  role = aws_iam_role.ecs_instance_role.name
-}
-
-# Create dedicated IAM Role and policy for Chaosmonkey batch job
-data "template_file" "job_role_policy_template" {
-  template = file("./templates/iam_policies/job_role_policy.tpl")
-
-  vars = {}
-}
-
-resource "aws_iam_role" "job_role" {
-  name               = "${local.name_prefix}-job-role"
-  assume_role_policy = data.template_file.ecs_assume_role_template.rendered
-}
-
-resource "aws_iam_role_policy" "job_policy" {
-  name = "batch_sts_policy"
-  role = aws_iam_role.job_role.name
-
-  policy = data.template_file.job_role_policy_template.rendered
-}
+## Tests implemented by AdRoc in dev environments only (not in any other higher 
+## environments) so removing the resources in dev and keeping the code for reference only
+#
+## Fetch local context, e.g. current account id for arn strings
+#data "aws_caller_identity" "current" {
+#}
+#
+## Create a Service Role for AWS Batch to run under
+#data "template_file" "batch_assume_role_template" {
+#  template = file(
+#    "${path.module}/templates/iam_policies/batch_assume_policy.tpl",
+#  )
+#
+#  vars = {}
+#}
+#
+#resource "aws_iam_role" "batch_service_role" {
+#  name = "${local.name_prefix}-batch-role"
+#
+#  assume_role_policy = data.template_file.batch_assume_role_template.rendered
+#}
+#
+## Use existing managed iam policy for ECS instances - May want to copy and manage this separately
+#resource "aws_iam_role_policy_attachment" "batch_service_role_policy_attachment" {
+#  role       = aws_iam_role.batch_service_role.name
+#  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+#}
+#
+## Create the EC2 Instance role ECS instances will run under
+#data "template_file" "ecs_assume_role_template" {
+#  template = file(
+#    "${path.module}/templates/iam_policies/ecs_assume_policy.tpl",
+#  )
+#
+#  vars = {}
+#}
+#
+#resource "aws_iam_role" "ecs_instance_role" {
+#  name = "${local.name_prefix}-ecs-role"
+#
+#  assume_role_policy = data.template_file.ecs_assume_role_template.rendered
+#}
+#
+## Use existing managed iam policy for ECS instances - May want to copy and manage this separately
+#resource "aws_iam_role_policy_attachment" "ecs_instance_role_policy_attachement" {
+#  role       = aws_iam_role.ecs_instance_role.name
+#  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+#}
+#
+#resource "aws_iam_instance_profile" "ecs_instance_profile" {
+#  name = "${local.name_prefix}-ecs-profile"
+#  role = aws_iam_role.ecs_instance_role.name
+#}
+#
+## Create dedicated IAM Role and policy for Chaosmonkey batch job
+#data "template_file" "job_role_policy_template" {
+#  template = file("./templates/iam_policies/job_role_policy.tpl")
+#
+#  vars = {}
+#}
+#
+#resource "aws_iam_role" "job_role" {
+#  name               = "${local.name_prefix}-job-role"
+#  assume_role_policy = data.template_file.ecs_assume_role_template.rendered
+#}
+#
+#resource "aws_iam_role_policy" "job_policy" {
+#  name = "batch_sts_policy"
+#  role = aws_iam_role.job_role.name
+#
+#  policy = data.template_file.job_role_policy_template.rendered
+#}
 

--- a/testing/chaosmonkey/iam.tf
+++ b/testing/chaosmonkey/iam.tf
@@ -1,6 +1,7 @@
 ## Tests implemented by AdRoc in dev environments only (not in any other higher 
 ## environments) so removing the resources in dev and keeping the code for reference only
 #
+#
 ## Fetch local context, e.g. current account id for arn strings
 #data "aws_caller_identity" "current" {
 #}


### PR DESCRIPTION
Action to fix jr-ancillary-network pipeline.
Chaos Monkey tests implemented by AdRoc in dev environments only (not in any other higher environments) so removing the resources in dev and keeping the code for reference only 
https://dsdmoj.atlassian.net/browse/NIT-343